### PR TITLE
Stop the listener on signalling channel closure and add tests

### DIFF
--- a/.aegir.cjs
+++ b/.aegir.cjs
@@ -9,7 +9,7 @@ process.on('beforeExit', (code) => process.exit(code))
 const ECHO_PROTOCOL = '/echo/1.0.0'
 
 async function before () {
-  const { webRTCDirect } = await import('./dist/src/index.js')
+  const { webRTCDirect, WebRTCDirectNodeType } = await import('./dist/src/index.js')
   const { pipe } = await import('it-pipe')
   const { multiaddr } = await import('@multiformats/multiaddr')
   const { mockUpgrader, mockRegistrar } = await import('@libp2p/interface-mocks')
@@ -31,7 +31,9 @@ async function before () {
 
   const peerId = peerIdFromString('QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo2a')
   const wd = webRTCDirect({
-    wrtc
+    wrtc,
+    enableSignalling: true,
+    nodeType: WebRTCDirectNodeType.Relay
   })({
     peerId: peerId
   })

--- a/.aegir.cjs
+++ b/.aegir.cjs
@@ -11,12 +11,9 @@ const ECHO_PROTOCOL = '/echo/1.0.0'
 async function before () {
   const { webRTCDirect, WebRTCDirectNodeType } = await import('./dist/src/index.js')
   const { pipe } = await import('it-pipe')
-  const { multiaddr } = await import('@multiformats/multiaddr')
   const { mockUpgrader, mockRegistrar } = await import('@libp2p/interface-mocks')
   const { peerIdFromString } = await import('@libp2p/peer-id')
-
-  const REMOTE_MULTIADDR_IP4 = multiaddr('/ip4/127.0.0.1/tcp/12345/http/p2p-webrtc-direct')
-  const REMOTE_MULTIADDR_IP6 = multiaddr('/ip6/::1/tcp/12346/http/p2p-webrtc-direct')
+  const { REMOTE_MULTIADDR_IP4, REMOTE_MULTIADDR_IP6 } = await import('./dist/test/constants.js')
 
   const registrar = mockRegistrar()
   void registrar.handle(ECHO_PROTOCOL, ({ stream }) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/webrtc-direct",
-  "version": "5.0.0-laconic-0.1.1",
+  "version": "5.0.0-laconic-0.1.2",
   "description": "Dial using WebRTC without the need to set up any Signalling Rendezvous Point! ",
   "license": "Apache-2.0 OR MIT",
   "homepage": "https://github.com/libp2p/js-libp2p-webrtc-direct#readme",

--- a/package.json
+++ b/package.json
@@ -155,6 +155,7 @@
     "p-defer": "^4.0.0",
     "p-event": "^5.0.1",
     "timed-cache": "^2.0.0",
+    "timeout-abort-controller": "^3.0.0",
     "uint8arrays": "^4.0.2",
     "undici": "^5.2.0",
     "wherearewe": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "release": "aegir release"
   },
   "dependencies": {
-    "@cerc-io/webrtc-peer": "^2.0.2-laconic-0.1.2",
+    "@cerc-io/webrtc-peer": "^2.0.2-laconic-0.1.3",
     "@libp2p/interface-transport": "^2.0.0",
     "@libp2p/interfaces": "^3.0.3",
     "@libp2p/logger": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "release": "aegir release"
   },
   "dependencies": {
-    "@cerc-io/webrtc-peer": "^2.0.2-laconic-0.1.0",
+    "@cerc-io/webrtc-peer": "^2.0.2-laconic-0.1.2",
     "@libp2p/interface-transport": "^2.0.0",
     "@libp2p/interfaces": "^3.0.3",
     "@libp2p/logger": "^2.0.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -318,8 +318,8 @@ class WebRTCDirect implements Transport {
         // Register signalling channel with the listener
         // (this.peerListener is set in this.createListener which is called for the provided listen address)
         // (only single listen address supported for now)
-        if ((this.peerListener?.server) != null) {
-          this.peerListener.server.registerSignallingChannel(signallingChannel)
+        if ((this.peerListener) != null) {
+          this.peerListener.registerSignallingChannel(signallingChannel)
         }
 
         // For signalling channels from peer to relay nodes
@@ -347,6 +347,11 @@ class WebRTCDirect implements Transport {
 
         // Unset the signalling channel for this peer
         delete this.signallingChannel
+
+        // Deregister this signalling channel from the listener
+        if ((this.peerListener) != null) {
+          this.peerListener.deRegisterSignallingChannel()
+        }
 
         // Open a new signalling channel if peer connection still exists
         this._createSignallingChannel(channel)

--- a/src/index.ts
+++ b/src/index.ts
@@ -346,7 +346,7 @@ class WebRTCDirect implements Transport {
         log('signalling channel closed')
 
         // Unset the signalling channel for this peer
-        delete this.signallingChannel
+        this.signallingChannel = undefined
 
         // Deregister this signalling channel from the listener
         if ((this.peerListener) != null) {

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -111,7 +111,7 @@ export class WebRTCDirectListener extends EventEmitter<ListenerEvents> implement
 
     // Unset this.multiaddr as this listener becomes inactive if signalling channel is closed
     // Dispatch 'close' event so that node's announce addresses get updated (through getAddrs())
-    delete this.multiaddr
+    this.multiaddr = undefined
     this.dispatchEvent(new CustomEvent('close'))
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -130,7 +130,7 @@ export class WebRTCDirectSigServer extends EventEmitter<WebRTCDirectServerEvents
   }
 
   deRegisterSignallingChannel () {
-    delete this.signallingChannel
+    this.signallingChannel = undefined
   }
 
   async close () {

--- a/src/server.ts
+++ b/src/server.ts
@@ -129,6 +129,10 @@ export class WebRTCDirectSigServer extends EventEmitter<WebRTCDirectServerEvents
     channel.handleSignal(incSignal)
   }
 
+  deRegisterSignallingChannel () {
+    delete this.signallingChannel
+  }
+
   async close () {
     await Promise.all(
       this.channels.map(async (channel) => await channel.close())

--- a/test/browser.ts
+++ b/test/browser.ts
@@ -5,10 +5,15 @@ import dialTests from './dial.js'
 import { webRTCDirect } from '../src/index.js'
 
 describe('browser RTC', () => {
-  const peerId = peerIdFromString('QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo2a')
-  const create = async () => {
-    const ws = webRTCDirect()({
-      peerId
+  const peerId = peerIdFromString('QmWeo5ZWjC7mVDNsbBub6WfcuT3MktVuKF7MMBXKrTMCsE')
+  const signallingPeerId = peerIdFromString('QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo2a')
+
+  const create = async (peerIdArg = peerId) => {
+    const ws = webRTCDirect({
+      enableSignalling: true,
+      relayPeerId: signallingPeerId.toString()
+    })({
+      peerId: peerIdArg
     })
 
     return ws

--- a/test/browser.ts
+++ b/test/browser.ts
@@ -1,17 +1,14 @@
 
-import { peerIdFromString } from '@libp2p/peer-id'
 import listenTests from './listen.js'
 import dialTests from './dial.js'
 import { webRTCDirect } from '../src/index.js'
+import { PEER_ID, SIG_PEER_ID } from './constants.js'
 
 describe('browser RTC', () => {
-  const peerId = peerIdFromString('QmWeo5ZWjC7mVDNsbBub6WfcuT3MktVuKF7MMBXKrTMCsE')
-  const signallingPeerId = peerIdFromString('QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo2a')
-
-  const create = async (peerIdArg = peerId) => {
+  const create = async (peerIdArg = PEER_ID) => {
     const ws = webRTCDirect({
       enableSignalling: true,
-      relayPeerId: signallingPeerId.toString()
+      relayPeerId: SIG_PEER_ID.toString()
     })({
       peerId: peerIdArg
     })

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -1,0 +1,12 @@
+import { peerIdFromString } from '@libp2p/peer-id'
+import { multiaddr } from '@multiformats/multiaddr'
+
+export const ECHO_PROTOCOL = '/echo/1.0.0'
+
+export const REMOTE_MULTIADDR_IP4 = multiaddr('/ip4/127.0.0.1/tcp/12345/http/p2p-webrtc-direct')
+export const REMOTE_MULTIADDR_IP6 = multiaddr('/ip6/::1/tcp/12346/http/p2p-webrtc-direct')
+
+export const PEER_ID = peerIdFromString('QmWeo5ZWjC7mVDNsbBub6WfcuT3MktVuKF7MMBXKrTMCsE')
+export const PEER_ID_1 = peerIdFromString('QmP7kBSdTjivW1e8zMnjUHkHCYFzVMuN14ycqyoRz3aJor')
+export const SIG_PEER_ID = peerIdFromString('QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo2a')
+export const REMOTE_MULTIADDR_IP4_PEER = multiaddr(`${REMOTE_MULTIADDR_IP4.toString()}/p2p/${SIG_PEER_ID.toString()}`)

--- a/test/dial.ts
+++ b/test/dial.ts
@@ -122,7 +122,7 @@ export default (create: (peerIdArg?: PeerId) => Promise<Transport>) => {
   })
 
   describe('dial using signalling channel', function () {
-    this.timeout(20 * 1000)
+    this.timeout(30 * 1000)
 
     const registrar = mockRegistrar()
     void registrar.handle(ECHO_PROTOCOL, ({ stream }) => {

--- a/test/dial.ts
+++ b/test/dial.ts
@@ -7,13 +7,21 @@ import all from 'it-all'
 import { fromString } from 'uint8arrays/from-string'
 import { mockRegistrar, mockUpgrader } from '@libp2p/interface-mocks'
 import type { Transport, Upgrader } from '@libp2p/interface-transport'
+import type { Connection } from '@libp2p/interface-connection'
+import type { PeerId } from '@libp2p/interface-peer-id'
 import type { Uint8ArrayList } from 'uint8arraylist'
 import type { Source } from 'it-stream-types'
+import { pEvent } from 'p-event'
+import { TimeoutController } from 'timeout-abort-controller'
 
-// this node is started in aegir.cjs before the test run
-const REMOTE_MULTIADDR_IP4 = multiaddr('/ip4/127.0.0.1/tcp/12345/http/p2p-webrtc-direct')
-const REMOTE_MULTIADDR_IP6 = multiaddr('/ip6/::1/tcp/12346/http/p2p-webrtc-direct')
-const ECHO_PROTOCOL = '/echo/1.0.0'
+import { P2P_WEBRTC_STAR_ID } from '../src/constants.js'
+import {
+  ECHO_PROTOCOL,
+  REMOTE_MULTIADDR_IP4,
+  REMOTE_MULTIADDR_IP6,
+  REMOTE_MULTIADDR_IP4_PEER,
+  PEER_ID_1
+} from './constants.js'
 
 async function * toBytes (source: Source<Uint8ArrayList>) {
   for await (const list of source) {
@@ -21,16 +29,15 @@ async function * toBytes (source: Source<Uint8ArrayList>) {
   }
 }
 
-export default (create: () => Promise<Transport>) => {
+export default (create: (peerIdArg?: PeerId) => Promise<Transport>) => {
   describe('dial', function () {
     this.timeout(20 * 1000)
 
     let upgrader: Upgrader
 
     beforeEach(() => {
-      const protocol = '/echo/1.0.0'
       const registrar = mockRegistrar()
-      void registrar.handle(protocol, ({ stream }) => {
+      void registrar.handle(ECHO_PROTOCOL, ({ stream }) => {
         void pipe(
           stream,
           stream
@@ -111,6 +118,136 @@ export default (create: () => Promise<Transport>) => {
 
       expect(values).to.deep.equal([data])
       await conn.close()
+    })
+  })
+
+  describe('dial using signalling channel', function () {
+    this.timeout(20 * 1000)
+
+    const registrar = mockRegistrar()
+    void registrar.handle(ECHO_PROTOCOL, ({ stream }) => {
+      void pipe(
+        stream,
+        stream
+      )
+    })
+    const upgrader = mockUpgrader({ registrar })
+
+    let wd: Transport
+    let conn: Connection
+    let conn1: Connection
+
+    const listenMultiaddr = multiaddr(`${REMOTE_MULTIADDR_IP4_PEER.toString()}/${P2P_WEBRTC_STAR_ID}`)
+    const dialAddress1 = multiaddr(`${listenMultiaddr.toString()}/p2p/${PEER_ID_1.toString()}`)
+
+    beforeEach(async () => {
+      wd = await create()
+    })
+
+    afterEach(async () => {
+      await conn.close()
+      await conn1.close()
+    })
+
+    it('dial on IPv4', async () => {
+      const listener = wd.createListener({ upgrader })
+      await listener.listen(listenMultiaddr)
+
+      conn = await wd.dial(REMOTE_MULTIADDR_IP4_PEER, { upgrader })
+
+      // Wait for peer to join signalling network
+      await new Promise((resolve) => setTimeout(resolve, 2000))
+
+      const wd1 = await create(PEER_ID_1)
+      const listener1 = wd1.createListener({ upgrader })
+      await listener1.listen(listenMultiaddr)
+
+      conn1 = await wd1.dial(REMOTE_MULTIADDR_IP4_PEER, { upgrader })
+
+      // Wait for peer to join signalling network
+      await new Promise((resolve) => setTimeout(resolve, 2000))
+
+      // Dial and wait for listener to know of the connect
+      const connToNewPeer = await wd.dial(dialAddress1, { upgrader })
+      await pEvent(listener1, 'connection')
+
+      const stream = await connToNewPeer.newStream(ECHO_PROTOCOL)
+      const data = fromString('some data')
+
+      const values = await pipe(
+        [data],
+        stream,
+        toBytes,
+        async (source) => await all(source)
+      )
+
+      expect(values).to.deep.equal([data])
+
+      await connToNewPeer.close()
+    })
+
+    it('dials the same peer twice', async () => {
+      const listener = wd.createListener({ upgrader })
+      await listener.listen(listenMultiaddr)
+
+      conn = await wd.dial(REMOTE_MULTIADDR_IP4_PEER, { upgrader })
+
+      // Wait for peer to join signalling network
+      await new Promise((resolve) => setTimeout(resolve, 2000))
+
+      const wd1 = await create(PEER_ID_1)
+      const listener1 = wd1.createListener({ upgrader })
+      await listener1.listen(listenMultiaddr)
+
+      conn1 = await wd1.dial(REMOTE_MULTIADDR_IP4_PEER, { upgrader })
+
+      // Wait for peer to join signalling network
+      await new Promise((resolve) => setTimeout(resolve, 2000))
+
+      // Dial and wait for listener to know of the connect
+      const conn1ToNewPeer = await wd.dial(dialAddress1, { upgrader })
+      const conn2ToNewPeer = await wd.dial(dialAddress1, { upgrader })
+
+      const values = await Promise.all(
+        [conn1ToNewPeer, conn2ToNewPeer].map(async connToNewPeer => {
+          const stream = await connToNewPeer.newStream(ECHO_PROTOCOL)
+          const data = fromString('some data ' + connToNewPeer.id)
+
+          const values = await pipe(
+            [data],
+            stream,
+            toBytes,
+            async (source) => await all(source)
+          )
+
+          return values
+        })
+      )
+
+      expect(values).to.deep.equal([[
+        fromString('some data ' + conn1ToNewPeer.id)
+      ], [
+        fromString('some data ' + conn2ToNewPeer.id)
+      ]])
+
+      await conn1ToNewPeer.close()
+      await conn2ToNewPeer.close()
+    })
+
+    it('dial offline / non-existent node on IPv4, check callback', async () => {
+      const listener = wd.createListener({ upgrader })
+      await listener.listen(listenMultiaddr)
+
+      conn = await wd.dial(REMOTE_MULTIADDR_IP4_PEER, { upgrader })
+
+      // Wait for peer to join signalling network
+      await new Promise((resolve) => setTimeout(resolve, 2000))
+
+      const dialTimeout = 5000 // 5 sec
+      const timeoutController = new TimeoutController(dialTimeout)
+
+      // Expect an attempt to dial to another non-existent peer to fail
+      await expect(wd.dial(dialAddress1, { upgrader, signal: timeoutController.signal })).to.eventually.be.rejected()
     })
   })
 }

--- a/test/filter.spec.ts
+++ b/test/filter.spec.ts
@@ -5,6 +5,7 @@ import { multiaddr } from '@multiformats/multiaddr'
 import { peerIdFromString } from '@libp2p/peer-id'
 import { webRTCDirect } from '../src/index.js'
 
+// TODO Update
 describe('filter', () => {
   const peerId = peerIdFromString('QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo2a')
   it('filters non valid webrtc-direct multiaddrs', () => {

--- a/test/filter.spec.ts
+++ b/test/filter.spec.ts
@@ -2,15 +2,34 @@
 
 import { expect } from 'aegir/chai'
 import { multiaddr } from '@multiformats/multiaddr'
-import { peerIdFromString } from '@libp2p/peer-id'
-import { webRTCDirect } from '../src/index.js'
 
-// TODO Update
+import { P2P_WEBRTC_STAR_ID, WebRTCDirectNodeType, webRTCDirect } from '../src/index.js'
+import { PEER_ID, PEER_ID_1, REMOTE_MULTIADDR_IP4, REMOTE_MULTIADDR_IP4_PEER, SIG_PEER_ID } from './constants.js'
+
 describe('filter', () => {
-  const peerId = peerIdFromString('QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo2a')
-  it('filters non valid webrtc-direct multiaddrs', () => {
+  // Peer listen address (using primary relay peer id)
+  const peerSigListenAddr = `${REMOTE_MULTIADDR_IP4_PEER.toString()}/${P2P_WEBRTC_STAR_ID}`
+  // Invalid peer listen address (not using primary relay peer id)
+  const peerSigInvalidListenAddr = `${REMOTE_MULTIADDR_IP4.toString()}/p2p/${PEER_ID_1.toString()}/${P2P_WEBRTC_STAR_ID}`
+
+  // Peer dial (through signalling channel) address
+  const peerSigDialAddr = `${REMOTE_MULTIADDR_IP4_PEER.toString()}/${P2P_WEBRTC_STAR_ID}/p2p/${PEER_ID_1.toString()}`
+  // Invalid peer dial (through signalling channel) address (not having 'p2p-webrtc-direct')
+  const peerInvalidSigDialAddr = `/ip4/127.0.0.1/tcp/9090/ipfs/${SIG_PEER_ID.toString()}/${P2P_WEBRTC_STAR_ID}/p2p/${PEER_ID_1.toString()}`
+
+  it('filter a single addr for this transport', () => {
     const wd = webRTCDirect()({
-      peerId
+      peerId: PEER_ID
+    })
+    const ma = multiaddr('/ip4/127.0.0.1/tcp/9090/http/p2p-webrtc-direct')
+
+    const filtered = wd.filter([ma])
+    expect(filtered.length).to.equal(1)
+  })
+
+  it('filters non valid webrtc-direct multiaddrs (signalling disabled)', () => {
+    const wd = webRTCDirect()({
+      peerId: PEER_ID
     })
     const maArr = [
       multiaddr('/ip4/1.2.3.4/tcp/3456/http/p2p-webrtc-direct'),
@@ -18,20 +37,43 @@ describe('filter', () => {
       multiaddr('/ip4/127.0.0.1/tcp/9090/ws/p2p-webrtc-direct/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo2'),
       multiaddr('/ip4/127.0.0.1/tcp/9090/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4'),
       multiaddr('/ip4/127.0.0.1/tcp/9090/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4' +
-        '/p2p-circuit/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo5')
+        '/p2p-circuit/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo5'),
+      multiaddr(peerSigListenAddr),
+      multiaddr(peerSigDialAddr)
     ]
 
     const filtered = wd.filter(maArr)
     expect(filtered.length).to.equal(1)
   })
 
-  it('filter a single addr for this transport', () => {
-    const wd = webRTCDirect()({
-      peerId
+  it('filters non valid webrtc-direct multiaddrs (signalling enabled)', () => {
+    const wd = webRTCDirect({
+      enableSignalling: true,
+      nodeType: WebRTCDirectNodeType.Peer,
+      relayPeerId: SIG_PEER_ID.toString()
+    })({
+      peerId: PEER_ID
     })
-    const ma = multiaddr('/ip4/127.0.0.1/tcp/9090/http/p2p-webrtc-direct')
+    const maArr = [
+      multiaddr('/ip4/1.2.3.4/tcp/3456/http/p2p-webrtc-direct'),
+      multiaddr('/ip4/127.0.0.1/tcp/9090/ws'),
+      multiaddr('/ip4/127.0.0.1/tcp/9090/ws/p2p-webrtc-direct/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo2'),
+      multiaddr('/ip4/127.0.0.1/tcp/9090/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4'),
+      multiaddr('/ip4/127.0.0.1/tcp/9090/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo4' +
+        '/p2p-circuit/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSoooo5'),
+      multiaddr(peerSigListenAddr),
+      multiaddr(peerSigInvalidListenAddr),
+      multiaddr(peerSigDialAddr),
+      multiaddr(peerInvalidSigDialAddr)
+    ]
 
-    const filtered = wd.filter([ma])
-    expect(filtered.length).to.equal(1)
+    const expectedAddrs = [
+      multiaddr('/ip4/1.2.3.4/tcp/3456/http/p2p-webrtc-direct'),
+      multiaddr(peerSigListenAddr),
+      multiaddr(peerSigDialAddr)
+    ]
+    const filtered = wd.filter(maArr)
+
+    expect(filtered).to.eql(expectedAddrs)
   })
 })

--- a/test/instance.spec.ts
+++ b/test/instance.spec.ts
@@ -1,14 +1,13 @@
 /* eslint-env mocha */
 
 import { expect } from 'aegir/chai'
-import { peerIdFromString } from '@libp2p/peer-id'
 import { webRTCDirect } from '../src/index.js'
+import { PEER_ID } from './constants.js'
 
 describe('instances', () => {
   it('create', (done) => {
-    const peerId = peerIdFromString('QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo2a')
     const wdirect = webRTCDirect()({
-      peerId
+      peerId: PEER_ID
     })
     expect(wdirect).to.exist()
     done()

--- a/test/listen.ts
+++ b/test/listen.ts
@@ -236,7 +236,7 @@ export default (create: (peerIdArg?: PeerId) => Promise<Transport>) => {
       })
 
       await listener.listen(listenMultiaddr)
-      await wd.dial(REMOTE_MULTIADDR_IP4_PEER, { upgrader })
+      conn = await wd.dial(REMOTE_MULTIADDR_IP4_PEER, { upgrader })
 
       await eventPromise.promise
     })
@@ -280,6 +280,8 @@ export default (create: (peerIdArg?: PeerId) => Promise<Transport>) => {
       // Wait for listener addrs to be updated
       await new Promise((resolve) => setTimeout(resolve, 100))
       expect(listener.getAddrs()).to.be.empty()
+
+      await listener.close()
     })
 
     it('getAddrs', async () => {
@@ -307,7 +309,7 @@ export default (create: (peerIdArg?: PeerId) => Promise<Transport>) => {
       const listener = wd.createListener({ upgrader })
 
       await listener.listen(listenMultiaddr)
-      await wd.dial(REMOTE_MULTIADDR_IP4_PEER, { upgrader })
+      conn = await wd.dial(REMOTE_MULTIADDR_IP4_PEER, { upgrader })
 
       // Wait for peer to join signalling network
       await new Promise((resolve) => setTimeout(resolve, 2000))
@@ -316,7 +318,7 @@ export default (create: (peerIdArg?: PeerId) => Promise<Transport>) => {
       const listener1 = wd1.createListener({ upgrader })
 
       await listener1.listen(listenMultiaddr)
-      conn = await wd1.dial(REMOTE_MULTIADDR_IP4_PEER, { upgrader })
+      const conn1 = await wd1.dial(REMOTE_MULTIADDR_IP4_PEER, { upgrader })
 
       // Wait for peer to join signalling network
       await new Promise((resolve) => setTimeout(resolve, 2000))
@@ -337,6 +339,7 @@ export default (create: (peerIdArg?: PeerId) => Promise<Transport>) => {
 
       await listener.close()
       await listener1.close()
+      await conn1.close()
     })
 
     it('should have remoteAddress in listener connection', async function () {
@@ -352,7 +355,7 @@ export default (create: (peerIdArg?: PeerId) => Promise<Transport>) => {
       const listener = wd.createListener({ upgrader })
 
       await listener.listen(listenMultiaddr)
-      await wd.dial(REMOTE_MULTIADDR_IP4_PEER, { upgrader })
+      conn = await wd.dial(REMOTE_MULTIADDR_IP4_PEER, { upgrader })
 
       // Wait for peer to join signalling network
       await new Promise((resolve) => setTimeout(resolve, 2000))
@@ -366,7 +369,7 @@ export default (create: (peerIdArg?: PeerId) => Promise<Transport>) => {
       })
 
       await listener1.listen(listenMultiaddr)
-      conn = await wd1.dial(REMOTE_MULTIADDR_IP4_PEER, { upgrader })
+      const conn1 = await wd1.dial(REMOTE_MULTIADDR_IP4_PEER, { upgrader })
 
       // Wait for peer to join signalling network
       await new Promise((resolve) => setTimeout(resolve, 2000))
@@ -377,6 +380,7 @@ export default (create: (peerIdArg?: PeerId) => Promise<Transport>) => {
       await connToNewPeer.close()
       await listener.close()
       await listener1.close()
+      await conn1.close()
     })
   })
 }

--- a/test/listen.ts
+++ b/test/listen.ts
@@ -196,7 +196,7 @@ export default (create: (peerIdArg?: PeerId) => Promise<Transport>) => {
   })
 
   describe('listen using signalling channel', function () {
-    this.timeout(20 * 1000)
+    this.timeout(30 * 1000)
 
     const registrar = mockRegistrar()
     const upgrader = mockUpgrader({ registrar })

--- a/test/node.ts
+++ b/test/node.ts
@@ -1,25 +1,21 @@
-
-import { peerIdFromString } from '@libp2p/peer-id'
 import listenTests from './listen.js'
 import complianceTests from './compliance.js'
 import dialTests from './dial.js'
 // @ts-expect-error no types
 import wrtc from 'wrtc'
 import { webRTCDirect } from '../src/index.js'
+import { PEER_ID, SIG_PEER_ID } from './constants.js'
 
 // TODO: Temporary fix per wrtc issue
 // https://github.com/node-webrtc/node-webrtc/issues/636#issuecomment-774171409
 process.on('beforeExit', (code) => process.exit(code))
 
 describe('transport: with wrtc', () => {
-  const peerId = peerIdFromString('QmWeo5ZWjC7mVDNsbBub6WfcuT3MktVuKF7MMBXKrTMCsE')
-  const signallingPeerId = peerIdFromString('QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo2a')
-
-  const create = async (peerIdArg = peerId) => {
+  const create = async (peerIdArg = PEER_ID) => {
     const ws = webRTCDirect({
       wrtc,
       enableSignalling: true,
-      relayPeerId: signallingPeerId.toString()
+      relayPeerId: SIG_PEER_ID.toString()
     })({
       peerId: peerIdArg
     })

--- a/test/node.ts
+++ b/test/node.ts
@@ -12,13 +12,16 @@ import { webRTCDirect } from '../src/index.js'
 process.on('beforeExit', (code) => process.exit(code))
 
 describe('transport: with wrtc', () => {
-  const peerId = peerIdFromString('QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo2a')
-  const create = async () => {
+  const peerId = peerIdFromString('QmWeo5ZWjC7mVDNsbBub6WfcuT3MktVuKF7MMBXKrTMCsE')
+  const signallingPeerId = peerIdFromString('QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo2a')
+
+  const create = async (peerIdArg = peerId) => {
     const ws = webRTCDirect({
       wrtc,
-      enableSignalling: false
+      enableSignalling: true,
+      relayPeerId: signallingPeerId.toString()
     })({
-      peerId
+      peerId: peerIdArg
     })
 
     return ws


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/289

- Stop the peer listener on signalling channel closure
- Add tests to listen and dial using the signalling channel
- Update filter tests for new listen and dial addresses