### PR TITLE
Upgrade webrtc-peer version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/webrtc-direct",
-  "version": "5.0.0-laconic-0.1.2",
+  "version": "5.0.0-laconic-0.1.3",
   "description": "Dial using WebRTC without the need to set up any Signalling Rendezvous Point! ",
   "license": "Apache-2.0 OR MIT",
   "homepage": "https://github.com/libp2p/js-libp2p-webrtc-direct#readme",
@@ -139,7 +139,7 @@
     "release": "aegir release"
   },
   "dependencies": {
-    "@cerc-io/webrtc-peer": "^2.0.2-laconic-0.1.3",
+    "@cerc-io/webrtc-peer": "^2.0.2-laconic-0.1.4",
     "@libp2p/interface-transport": "^2.0.0",
     "@libp2p/interfaces": "^3.0.3",
     "@libp2p/logger": "^2.0.1",

--- a/test/compliance.ts
+++ b/test/compliance.ts
@@ -6,7 +6,7 @@ import { multiaddr } from '@multiformats/multiaddr'
 
 export default (create: () => Promise<Transport>) => {
   describe('interface-transport compliance', function () {
-    this.timeout(20 * 1000)
+    this.timeout(30 * 1000)
 
     tests({
       async setup () {

--- a/test/dial.ts
+++ b/test/dial.ts
@@ -31,7 +31,7 @@ async function * toBytes (source: Source<Uint8ArrayList>) {
 
 export default (create: (peerIdArg?: PeerId) => Promise<Transport>) => {
   describe('dial', function () {
-    this.timeout(20 * 1000)
+    this.timeout(30 * 1000)
 
     let upgrader: Upgrader
 

--- a/test/listen.ts
+++ b/test/listen.ts
@@ -20,7 +20,7 @@ import {
 
 export default (create: (peerIdArg?: PeerId) => Promise<Transport>) => {
   describe('listen', function () {
-    this.timeout(20 * 1000)
+    this.timeout(30 * 1000)
 
     if (isBrowser) {
       return


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/289

- Upgrade `@cerc-io/webrtc-peer` to `v2.0.2-laconic-0.1.4`