### PR TITLE
Regularly check if signalling channel is closed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/webrtc-direct",
-  "version": "5.0.0-laconic-0.1.3",
+  "version": "5.0.0-laconic-0.1.4",
   "description": "Dial using WebRTC without the need to set up any Signalling Rendezvous Point! ",
   "license": "Apache-2.0 OR MIT",
   "homepage": "https://github.com/libp2p/js-libp2p-webrtc-direct#readme",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,3 +13,6 @@ export const CLOSE_TIMEOUT = 2000
 
 // TTL for time cache of seen signalling channel messages in relay nodes
 export const SEEN_CACHE_TTL = 30 * 1000 // 30 seconds
+
+// Interval (ms) to check if channel is closed
+export const CHANNEL_CLOSED_TIMEOUT = 5 * 1000 // 5 seconds

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,0 +1,17 @@
+import { logger } from '@libp2p/logger'
+
+import { CHANNEL_CLOSED_TIMEOUT } from './constants.js'
+
+const debugLog = logger('laconic:webrtc-direct:debug')
+
+export function setChannelClosingInterval (channel: RTCDataChannel, channelClosedHandler: () => void): NodeJS.Timer {
+  const closingInterval = setInterval(() => {
+    if (channel.readyState === 'closed') {
+      clearInterval(closingInterval)
+      debugLog('Cleaning up closed signalling channel')
+      channelClosedHandler()
+    }
+  }, CHANNEL_CLOSED_TIMEOUT)
+
+  return closingInterval
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,8 +17,10 @@ import { CODE_CIRCUIT, CODE_P2P, P2P_WEBRTC_STAR_ID } from './constants.js'
 import { toMultiaddrConnection } from './socket-to-conn.js'
 import { createListener, WebRTCDirectListener } from './listener.js'
 import { ConnectRequest, JoinRequest, SignallingChannelType, SignallingMessage } from './signal-message.js'
+import { setChannelClosingInterval } from './helpers.js'
 
 const log = logger('libp2p:webrtc-direct')
+const debugLog = logger('laconic:webrtc-direct:debug')
 
 export { P2P_WEBRTC_STAR_ID } from './constants.js'
 
@@ -335,14 +337,20 @@ class WebRTCDirect implements Transport {
           }
 
           const msg = uint8ArrayFromString(JSON.stringify(request))
-          signallingChannel.send(msg)
+
+          try {
+            signallingChannel.send(msg)
+          } catch (err: any) {
+            debugLog('_registerSignallingChannelHandler signalling channel send failed', err)
+            debugLog('signallingChannel.readyState', signallingChannel.readyState)
+          }
         }
 
         // Resolve deferredSignallingChannel promise
         deferredSignallingChannel.resolve()
       })
 
-      signallingChannel.addEventListener('close', () => {
+      const channelClosedHandler = () => {
         log('signalling channel closed')
 
         // Unset the signalling channel for this peer
@@ -355,7 +363,14 @@ class WebRTCDirect implements Transport {
 
         // Open a new signalling channel if peer connection still exists
         this._createSignallingChannel(channel)
-      })
+      }
+
+      const closingInterval = setChannelClosingInterval(signallingChannel, channelClosedHandler)
+
+      signallingChannel.addEventListener('close', () => {
+        clearInterval(closingInterval)
+        channelClosedHandler()
+      }, { once: true })
 
       signallingChannel.addEventListener('error', (evt) => {
         // @ts-expect-error ChannelErrorEvent is just an Event in the types?
@@ -498,7 +513,12 @@ class WebRTCDirect implements Transport {
             }
             signallingChannel.addEventListener('message', onMessage)
 
-            signallingChannel.send(uint8ArrayFromString(JSON.stringify(request)))
+            try {
+              signallingChannel.send(uint8ArrayFromString(JSON.stringify(request)))
+            } catch (err: any) {
+              debugLog('_registerSignallingChannelHandler signalling channel send failed', err)
+              debugLog('signallingChannel.readyState', signallingChannel.readyState)
+            }
           })
 
           const responseSignal = JSON.parse(responseSignalJson)

--- a/src/server.ts
+++ b/src/server.ts
@@ -393,13 +393,13 @@ export class WebRTCDirectServer extends EventEmitter<WebRTCDirectServerEvents> {
         signallingChannel.addEventListener('error', untrackChannel)
       }
 
-      // Keep track of the signalling channel from another relay node
-      if (type === SignallingChannelType.Relay) {
-        trackRelaySignallingChannel()
-      }
-
-      // Resolve deferredSignallingChannel promise when signalling channel opens
       signallingChannel.addEventListener('open', () => {
+        // Keep track of the signalling channel from another relay node
+        if (type === SignallingChannelType.Relay) {
+          trackRelaySignallingChannel()
+        }
+
+        // Resolve deferredSignallingChannel promise when signalling channel opens
         deferredSignallingChannel.resolve()
       })
 
@@ -416,6 +416,7 @@ export class WebRTCDirectServer extends EventEmitter<WebRTCDirectServerEvents> {
               throw new Error('Unexpected JoinRequest over relay signalling channel')
             }
 
+            // Keep track of the signalling channel from peer nodes
             trackPeerSignallingChannel(msg.peerId)
             return
           }

--- a/src/server.ts
+++ b/src/server.ts
@@ -17,8 +17,10 @@ import { sha256 } from 'multiformats/hashes/sha2'
 import { http } from './http-server.js'
 import { ConnectRequest, ConnectResponse, SignallingChannelType, SignallingMessage } from './signal-message.js'
 import { SEEN_CACHE_TTL } from './constants.js'
+import { setChannelClosingInterval } from './helpers.js'
 
 const log = logger('libp2p:webrtc-direct:listener')
+const debugLog = logger('laconic:webrtc-direct:debug')
 
 interface WebRTCDirectServerEvents {
   'error': CustomEvent<Error>
@@ -99,7 +101,13 @@ export class WebRTCDirectSigServer extends EventEmitter<WebRTCDirectServerEvents
         dst: request.src,
         signal: signalStr
       }
-      signallingChannel.send(uint8ArrayFromString(JSON.stringify(response)))
+
+      try {
+        signallingChannel.send(uint8ArrayFromString(JSON.stringify(response)))
+      } catch (err: any) {
+        debugLog('processRequest signalling channel send failed', err)
+        debugLog('signallingChannel.readyState', signallingChannel.readyState)
+      }
     })
     channel.addEventListener('error', (evt) => {
       const err = evt.detail
@@ -222,9 +230,12 @@ export class WebRTCDirectServer extends EventEmitter<WebRTCDirectServerEvents> {
       this.relaySignallingChannels = this.relaySignallingChannels.filter(c => c !== signallingChannel)
     }
 
-    signallingChannel.addEventListener('close', untrackChannel, {
-      once: true
-    })
+    const closingInterval = setChannelClosingInterval(signallingChannel, untrackChannel)
+
+    signallingChannel.addEventListener('close', () => {
+      clearInterval(closingInterval)
+      untrackChannel()
+    }, { once: true })
   }
 
   async processRequest (req: IncomingMessage, res: ServerResponse) {
@@ -356,7 +367,12 @@ export class WebRTCDirectServer extends EventEmitter<WebRTCDirectServerEvents> {
         const untrackChannel = () => {
           this.relaySignallingChannels = this.relaySignallingChannels.filter(s => s !== signallingChannel)
         }
-        signallingChannel.addEventListener('close', untrackChannel)
+        const closingInterval = setChannelClosingInterval(signallingChannel, untrackChannel)
+
+        signallingChannel.addEventListener('close', () => {
+          clearInterval(closingInterval)
+          untrackChannel()
+        }, { once: true })
         signallingChannel.addEventListener('error', untrackChannel)
       }
 
@@ -368,8 +384,12 @@ export class WebRTCDirectServer extends EventEmitter<WebRTCDirectServerEvents> {
         const untrackChannel = () => {
           this.peerSignallingChannelMap.delete(peerId)
         }
+        const closingInterval = setChannelClosingInterval(signallingChannel, untrackChannel)
 
-        signallingChannel.addEventListener('close', untrackChannel)
+        signallingChannel.addEventListener('close', () => {
+          clearInterval(closingInterval)
+          untrackChannel()
+        }, { once: true })
         signallingChannel.addEventListener('error', untrackChannel)
       }
 
@@ -436,7 +456,12 @@ export class WebRTCDirectServer extends EventEmitter<WebRTCDirectServerEvents> {
 
     // Forward peer signalling message to its destination if a signalling channel is present
     if (destPeerSignallingChannel != null) {
-      destPeerSignallingChannel.send(msg)
+      try {
+        destPeerSignallingChannel.send(msg)
+      } catch (err: any) {
+        debugLog('dest signalling channel send failed', err)
+        debugLog('destPeerSignallingChannel.readyState', destPeerSignallingChannel.readyState)
+      }
     } else {
       // Otherwise, forward the signalling message to all the connected relay nodes
       this.relaySignallingChannels.forEach(relaySignallingChannel => {
@@ -445,7 +470,12 @@ export class WebRTCDirectServer extends EventEmitter<WebRTCDirectServerEvents> {
           return
         }
 
-        relaySignallingChannel.send(msg)
+        try {
+          relaySignallingChannel.send(msg)
+        } catch (err: any) {
+          debugLog('relay signalling channel send failed', err)
+          debugLog('relaySignallingChannel.readyState', relaySignallingChannel.readyState)
+        }
       })
     }
   }


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/289

- Catch errors while sending signalling messages
- Regularly check if signalling channel is in `closed` state and run close handlers if not triggered by `close` event